### PR TITLE
Update to ocaml/setup-ocaml project.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        ocaml-compiler:
+          - 4.08.x
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup OCaml
-      uses: avsm/setup-ocaml@master
-    - name: Install depext module
-      run: opam install -y depext
-    - name: Pin locally
-      run: opam pin -y add --no-action .
-    - name: Install locally
-      run: opam depext -y -i duppy
-    - name: Build locally
-      run: eval $(opam env) && dune build
-    - name: Run tests locally
-      run: eval $(opam env) && dune runtest
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - name: Install locally
+        run: opam install . --deps-only --with-test
+      - name: Build locally
+        run: opam exec -- dune build
+      - name: Run tests locally
+        run: opam exec -- dune runtest


### PR DESCRIPTION
avsm/setup-ocaml is not supported anymore. Ongoing work is happening on ocaml/setup-ocaml

Not sure exactly about which OCaml versions are supported, the 4.03 lower bound in the README seems incompatible with the version of dune expected in dune-project. Dune 2.7 requires 4.08 or higher.