### PR TITLE
Use Re.Pcre instead of Pcre

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
 B src/**
 S src/**
 B +threads
-PKG pcre
+PKG re

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please read the COPYING file before using this software.
 
 - ocaml
 - findlib
-- ocaml-pcre
+- ocaml-re
 - dune
 
 ## Compilation:

--- a/dune-project
+++ b/dune-project
@@ -14,5 +14,5 @@
  (depends
   (ocaml (>= 4.07.0))
   dune
-  pcre)
+  re)
 )

--- a/duppy.opam
+++ b/duppy.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.7"}
-  "pcre"
+  "re"
   "odoc" {with-doc}
 ]
 build: [

--- a/examples/http.ml
+++ b/examples/http.ml
@@ -1,3 +1,5 @@
+module Pcre = Re.Pcre
+
 let non_blocking_queues = ref 3
 let maybe_blocking_queues = ref 1
 let files_path = ref ""
@@ -275,7 +277,7 @@ let cgi_handler process path h request =
           (Filename.quote tr_suffix) (Filename.quote suffix)
       in
       let sanitize s =
-        Pcre.replace ~pat:"-" ~templ:"_" (String.uppercase_ascii s)
+        Pcre.substitute ~rex:(Pcre.regexp "-") ~subst:(fun _ -> "_") (String.uppercase_ascii s)
       in
       let headers =
         List.map (fun (x, y) -> (sanitize x, y)) request.request_headers
@@ -341,7 +343,7 @@ let cgi_handler process path h request =
                       in
                       ignore (Unix.close_process (in_c, out_c));
                       let __pa_duppy_0 =
-                        let headers = Pcre.split ~pat:"\r\n" headers in
+                        let headers = Pcre.split ~rex:(Pcre.regexp "\r\n") headers in
                         parse_headers headers
                       in
                       Duppy.Monad.bind __pa_duppy_0 (fun headers ->
@@ -401,7 +403,7 @@ let handle_request h request =
 
 let parse_request h r =
   try
-    let headers = Pcre.split ~pat:"\r\n" r in
+    let headers = Pcre.split ~rex:(Pcre.regexp "\r\n") r in
     let __pa_duppy_0 =
       match headers with
         | e :: l ->

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name duppy)
  (public_name duppy)
- (libraries unix threads pcre)
+ (libraries unix threads re)
  (foreign_stubs
   (language c)
   (names duppy_stubs))

--- a/src/duppy.ml
+++ b/src/duppy.ml
@@ -20,6 +20,8 @@
 
  *****************************************************************************)
 
+module Pcre = Re.Pcre
+
 type fd = Unix.file_descr
 
 external poll :


### PR DESCRIPTION
Rationale: Pcre depends on an obsolete library:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1000004